### PR TITLE
ipython>=3.0.0 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
+  - "3.3"
+  - "3.4"
+  - "3.5"
 install: pip install -r requirements.txt --use-mirrors
 script: nosetests test_ipython_nose.py

--- a/ipython_nose.py
+++ b/ipython_nose.py
@@ -14,7 +14,7 @@ from nose.config import Config, all_config_files
 from nose.plugins.base import Plugin
 from nose.plugins.skip import SkipTest
 from nose.plugins.manager import DefaultPluginManager
-from IPython.core import displaypub, magic
+from IPython.core import display, magic
 
 
 class Template(string.Formatter):
@@ -45,31 +45,26 @@ class DummyUnittestStream:
 class NotebookLiveOutput(object):
     def __init__(self):
         self.output_id = 'ipython_nose_%s' % uuid.uuid4().hex
-        displaypub.publish_display_data(
-         u'IPython.core.displaypub.publish_html',
+        display.publish_display_data(
          {'text/html':'<div id="%s"></div>' % self.output_id})
-        displaypub.publish_display_data(
-         u'IPython.core.displaypub.publish_javascript',
+        display.publish_display_data(
          {'application/javascript':
           'document.%s = $("#%s");' % (self.output_id, self.output_id)})
 
     def finalize(self):
-        displaypub.publish_display_data(
-         u'IPython.core.displaypub.publish_javascript',
+        display.publish_display_data(
          {'application/javascript':
           'delete document.%s;' % self.output_id})
 
 
     def write_chars(self, chars):
-        displaypub.publish_display_data(
-         u'IPython.core.displaypub.publish_javascript',
+        display.publish_display_data(
          {'application/javascript':
           'document.%s.append($("<span>%s</span>"));' % (
                 self.output_id, cgi.escape(chars))})
 
     def write_line(self, line):
-        displaypub.publish_display_data(
-         u'IPython.core.displaypub.publish_javascript',
+        display.publish_display_data(
          {'application/javascript':
           'document.%s.append($("<div>%s</div>"));' % (
                 self.output_id, cgi.escape(line))})

--- a/setup.py
+++ b/setup.py
@@ -14,4 +14,5 @@ setup(
     license='README.rst',
     description='IPython extension to run nosetests against the current kernel.',
     long_description=long_description,
+    install_requires=['ipython>=3.0.0', 'nose'],
 )


### PR DESCRIPTION
- publish_display_data signature dropped the `source` parameter
- publish_display_data moved from displaypub to display

Based off `update-travis` (#10).
